### PR TITLE
Fixing disk check

### DIFF
--- a/check_disk_all.ps1
+++ b/check_disk_all.ps1
@@ -2,7 +2,7 @@ param([int] $warn = 20, [int] $critical = 10)
 
 . (Join-Path $PSScriptRoot checks_helper.ps1)
 
-$countervaluearray = (Get-counter  -Counter "\LogicalDisk(*)\% Free Space").countersamples | where {$_.InstanceName -ne "_total"} | Sort-Object InstanceName
+$countervaluearray = (Get-counter  -Counter "\LogicalDisk(*)\% Free Space").countersamples | where {$_.InstanceName -ne "_total" -and $_.InstanceName -notmatch "harddiskvolume"} | Sort-Object InstanceName
 
 $minvalue = 100
 $message = ""

--- a/check_disk_all.ps1
+++ b/check_disk_all.ps1
@@ -2,7 +2,7 @@ param([int] $warn = 20, [int] $critical = 10)
 
 . (Join-Path $PSScriptRoot checks_helper.ps1)
 
-$countervaluearray = (Get-counter  -Counter "\LogicalDisk(*)\% Free Space").countersamples | where {$_.InstanceName -ne “_total”} | Sort-Object InstanceName
+$countervaluearray = (Get-counter  -Counter "\LogicalDisk(*)\% Free Space").countersamples | where {$_.InstanceName -ne "_total"} | Sort-Object InstanceName
 
 $minvalue = 100
 $message = ""
@@ -10,9 +10,9 @@ $message = ""
 foreach ($countervalue in $countervaluearray) {
     $message += $countervalue.InstanceName + " " + [System.Math]::Round($countervalue.CookedValue,2) + "%; "
 
-    if($t.CookedValue -lt $minvalue)
+    if($countervalue.CookedValue -lt $minvalue)
     {
-        $minvalue = $t.CookedValue
+        $minvalue = $countervalue.CookedValue
     }
 }
 


### PR DESCRIPTION
The disk check had some bad quote characters and an incorrect variable name such that the check would always fail. I fixed. I also removed unnamed volumes from the check since these usually exist and don't need to be monitored (like recovery volumes).
